### PR TITLE
Use PHP 5.3 compatible array definition.

### DIFF
--- a/src/Luxifer/DQL/Datetime/ConvertTZ.php
+++ b/src/Luxifer/DQL/Datetime/ConvertTZ.php
@@ -34,11 +34,11 @@ class ConvertTZ extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $parts = [
+        $parts = array(
             $sqlWalker->walkArithmeticPrimary($this->dateExpression),
             $sqlWalker->walkStringPrimary($this->fromTZ),
             $sqlWalker->walkStringPrimary($this->toTZ)
-        ];
+        );
 
         return sprintf('CONVERT_TZ(%s)', implode(', ', $parts));
     }

--- a/src/Luxifer/DQL/Datetime/DateFormat.php
+++ b/src/Luxifer/DQL/Datetime/DateFormat.php
@@ -30,10 +30,10 @@ class DateFormat extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $parts = [
+        $parts = array(
             $sqlWalker->walkArithmeticPrimary($this->dateExpression),
             $sqlWalker->walkStringPrimary($this->dateFormat)
-        ];
+        );
 
         return sprintf('DATE_FORMAT(%s)', implode(', ', $parts));
     }


### PR DESCRIPTION
Hi!

I have just deployed your code to production and found out it is not PHP 5.3 compatible -( However, composer states that PHP 5.3 is enough. So we have 2 options from here: make these 2 functions PHP 5.3 compatible or update composer.json to require PHP 5.4. I'd prefer the former, hence my pull request.

Thanks in advance. 
