### PR TITLE
Make declareation of  `getSql` and `parse` compatible with doctrine  3.0 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "doctrine/orm": ">=2.2.3"
+        "php": ">=8.2",
+        "doctrine/orm": ">=3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/src/DQL/Datetime/ConvertTZ.php
+++ b/src/DQL/Datetime/ConvertTZ.php
@@ -16,7 +16,7 @@ class ConvertTZ extends FunctionNode
     public $fromTZ;
     public $toTZ;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -32,7 +32,7 @@ class ConvertTZ extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $parts = array(
             $sqlWalker->walkArithmeticPrimary($this->dateExpression),

--- a/src/DQL/Datetime/Date.php
+++ b/src/DQL/Datetime/Date.php
@@ -15,7 +15,7 @@ class Date extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Date extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DATE(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/DateDiff.php
+++ b/src/DQL/Datetime/DateDiff.php
@@ -16,7 +16,7 @@ class DateDiff extends FunctionNode
     public $firstDateExpression;
     public $secondDateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -26,7 +26,7 @@ class DateDiff extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DATEDIFF(' .
             $this->firstDateExpression->dispatch($sqlWalker) . ', ' .

--- a/src/DQL/Datetime/DateFormat.php
+++ b/src/DQL/Datetime/DateFormat.php
@@ -15,7 +15,7 @@ class DateFormat extends FunctionNode
     public $dateExpression;
     public $dateFormat;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -28,7 +28,7 @@ class DateFormat extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $parts = array(
             $sqlWalker->walkArithmeticPrimary($this->dateExpression),

--- a/src/DQL/Datetime/Day.php
+++ b/src/DQL/Datetime/Day.php
@@ -14,7 +14,7 @@ class Day extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -22,7 +22,7 @@ class Day extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DAY(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/DayOfMonth.php
+++ b/src/DQL/Datetime/DayOfMonth.php
@@ -15,7 +15,7 @@ class DayOfMonth extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class DayOfMonth extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DAYOFMONTH(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/DayOfWeek.php
+++ b/src/DQL/Datetime/DayOfWeek.php
@@ -15,7 +15,7 @@ class DayOfWeek extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class DayOfWeek extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DAYOFWEEK(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/DayOfYear.php
+++ b/src/DQL/Datetime/DayOfYear.php
@@ -15,7 +15,7 @@ class DayOfYear extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class DayOfYear extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DAYOFYEAR(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/FromUnixtime.php
+++ b/src/DQL/Datetime/FromUnixtime.php
@@ -15,7 +15,7 @@ class FromUnixtime extends FunctionNode
     public $dateExpression;
     public $dateFormat;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -27,7 +27,7 @@ class FromUnixtime extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $parts = array(
             $sqlWalker->walkArithmeticPrimary($this->dateExpression),

--- a/src/DQL/Datetime/Hour.php
+++ b/src/DQL/Datetime/Hour.php
@@ -15,7 +15,7 @@ class Hour extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Hour extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'HOUR(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Minute.php
+++ b/src/DQL/Datetime/Minute.php
@@ -15,7 +15,7 @@ class Minute extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Minute extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'MINUTE(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Month.php
+++ b/src/DQL/Datetime/Month.php
@@ -15,7 +15,7 @@ class Month extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Month extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker)" string
     {
         return 'MONTH(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Quarter.php
+++ b/src/DQL/Datetime/Quarter.php
@@ -14,7 +14,7 @@ class Quarter extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): string
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -22,7 +22,7 @@ class Quarter extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): void
     {
         return 'QUARTER(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Quarter.php
+++ b/src/DQL/Datetime/Quarter.php
@@ -14,7 +14,7 @@ class Quarter extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser): string
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -22,7 +22,7 @@ class Quarter extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker): void
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'QUARTER(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Second.php
+++ b/src/DQL/Datetime/Second.php
@@ -15,7 +15,7 @@ class Second extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Second extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'SECOND(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Time.php
+++ b/src/DQL/Datetime/Time.php
@@ -15,7 +15,7 @@ class Time extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Time extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'TIME(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Week.php
+++ b/src/DQL/Datetime/Week.php
@@ -14,7 +14,7 @@ class Week extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -22,7 +22,7 @@ class Week extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'WEEK(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Datetime/Year.php
+++ b/src/DQL/Datetime/Year.php
@@ -15,7 +15,7 @@ class Year extends FunctionNode
 {
     public $dateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -23,7 +23,7 @@ class Year extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'YEAR(' .
             $this->dateExpression->dispatch($sqlWalker) .

--- a/src/DQL/Numeric/Rand.php
+++ b/src/DQL/Numeric/Rand.php
@@ -9,14 +9,14 @@ use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 
 class Rand extends FunctionNode
 {
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'RAND()';
     }

--- a/src/DQL/String/ConcatWs.php
+++ b/src/DQL/String/ConcatWs.php
@@ -14,7 +14,7 @@ class ConcatWs extends FunctionNode
 {
     public $strings = array();
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $lexer = $parser->getLexer();
 
@@ -37,7 +37,7 @@ class ConcatWs extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $parts = array_map(array($sqlWalker, 'walkStringPrimary'), $this->strings);
 

--- a/src/DQL/String/IfElse.php
+++ b/src/DQL/String/IfElse.php
@@ -16,7 +16,7 @@ class IfElse extends FunctionNode
     public $isTrueStatement;
     public $isFalseStatement;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -31,7 +31,7 @@ class IfElse extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'IF(' .
             $this->condition->dispatch($sqlWalker) . ', ' .

--- a/src/DQL/String/Md5.php
+++ b/src/DQL/String/Md5.php
@@ -14,7 +14,7 @@ class Md5 extends FunctionNode
 {
     public $md5Expression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
@@ -22,7 +22,7 @@ class Md5 extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return 'MD5(' .
             $this->md5Expression->dispatch($sqlWalker) .


### PR DESCRIPTION
Make declareation of  `getSql` and `parse` compatible with doctrine  3.0 and up